### PR TITLE
Use separate directories for building and running

### DIFF
--- a/roles/github/templates/build-kayobe-docker-image.yml.j2
+++ b/roles/github/templates/build-kayobe-docker-image.yml.j2
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v3
         with:
            submodules: true
+           path: docker-image-build
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2
@@ -47,8 +48,8 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
-          file: ./.automation/docker/kayobe/Dockerfile
-          context: .
+          file: ./docker-image-build/.automation/docker/kayobe/Dockerfile
+          context: docker-image-build
           build-args: |
              KAYOBE_DOCKER_SSH_CONFIG_PATH=.automation/docker/kayobe/ssh_config
              KAYOBE_USER_UID=${{ env.KAYOBE_USER_UID }}

--- a/roles/github/templates/build-kayobe-docker-image.yml.j2
+++ b/roles/github/templates/build-kayobe-docker-image.yml.j2
@@ -36,11 +36,12 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           driver-opts: |
-            image=moby/buildkit:master
+            image=moby/buildkit:v0.12.1
 <%if github_buildx_inline_config | length >= 1 %>
           config-inline: |
             %% github_buildx_inline_config | indent(12) | trim %%
 <% endif %>
+          version: v0.11.2
 
 <% if github_kayobe_hook | length >= 1 %>
       %% github_kayobe_hook | indent(width=6, first=false) %%

--- a/roles/github/templates/generic.yml.j2
+++ b/roles/github/templates/generic.yml.j2
@@ -20,12 +20,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
+          path: kayobe-config
 
 <% if github_kayobe_hook | length >= 1 %>
       %% github_kayobe_hook | indent(width=6, first=false) %%
 <% endif %>
       - name: Symlink source checkout to expected location
-        run: sudo ln -s $PWD /src
+        run: sudo ln -s $PWD/kayobe-config /src
 
       - name: %% format_file_name(workflow.file_name, is_subtitle=true)  %%
         run: |

--- a/roles/github/templates/run-config-diff.yml.j2
+++ b/roles/github/templates/run-config-diff.yml.j2
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v3
         with:
            submodules: true
+           path: kayobe-config
            fetch-depth: 0
            ref: ${{ github.ref }}
 
@@ -34,7 +35,7 @@ jobs:
 <% endif %>
       - name: Copy checkout to expected location
         run: |
-            sudo cp -rf $GITHUB_WORKSPACE/ /src
+            sudo cp -rf $GITHUB_WORKSPACE/kayobe-config /src
             sudo chown stack:stack -Rf /src
 
       - name: Run config diff

--- a/roles/github/templates/run-tempest.yml.j2
+++ b/roles/github/templates/run-tempest.yml.j2
@@ -36,11 +36,12 @@ jobs:
 <% endif %>
       - name: Checkout kayobe config
         uses: actions/checkout@v3
+        path: kayobe-config
         with:
            submodules: true
 
       - name: Symlink source checkout to expected location
-        run: sudo ln -s $PWD /src
+        run: sudo ln -s $PWD/kayobe-config /src
 
 <% if github_kayobe_hook | length >= 1 %>
       %% github_kayobe_hook | indent(width=6, first=false) %%


### PR DESCRIPTION
Uses a separate directory for building the docker image and running the other workflows. This is because the user the is used by the docker git image is root which results in permission issues when the workflows try to run. This change means that the directories do not overlap, avoiding any permission issues.

Additionally pinned versions for buildkit and buildx