### PR TITLE
Add flag to disable provenance

### DIFF
--- a/roles/github/README.md
+++ b/roles/github/README.md
@@ -40,7 +40,7 @@ The following variables can be used to make small adjustments to the composition
 
 `github_image_name`: name of the kayobe image defaults to `kayobe`.
 
-`github_image_tag`: tag used to select kayobe image defaults to `latest` 
+`github_image_tag`: tag used to select kayobe image defaults to `latest`
 
 `github_registry_username`: username used to authenticate with the docker registry.
 
@@ -62,6 +62,8 @@ github_buildx_inline_config: |
 `github_timeout`: control how a long a job may run before being cancelled. Timeout is defined in minutes and defaults to 360 minutes (6 hours)
 
 If you wish to make more impactful changes such as which workflows are built and what they contain then see the list of dictionaries called `workflows` in `defaults/main.yml`
+
+`github_buildx_enable_provenance`: whether or not to enable build attestations/provenence. This causes issues on some clouds and so is defaulted to `false`.
 
 `github_workflows:` is a list of dictionaries that contains each of the workflows described above. A given list element is made up of the following:
 

--- a/roles/github/README.md
+++ b/roles/github/README.md
@@ -63,7 +63,7 @@ github_buildx_inline_config: |
 
 If you wish to make more impactful changes such as which workflows are built and what they contain then see the list of dictionaries called `workflows` in `defaults/main.yml`
 
-`github_buildx_enable_provenance`: whether or not to enable build attestations/provenence. This causes issues on some clouds and so is defaulted to `false`.
+`github_buildx_enable_provenance`: whether or not to enable build attestations/provenence. This has been [noted](https://github.com/docker/build-push-action/releases/tag/v4.1.1) to cause issues with docker registries such as Pulp. Default to false.
 
 `github_workflows:` is a list of dictionaries that contains each of the workflows described above. A given list element is made up of the following:
 

--- a/roles/github/defaults/main.yml
+++ b/roles/github/defaults/main.yml
@@ -25,6 +25,8 @@ github_buildx_inline_config: ""
 
 github_timeout: 360
 
+github_buildx_enable_provenance: false
+
 github_kayobe_limit_input: |
   kayobeLimit:
     description: |

--- a/roles/github/defaults/main.yml
+++ b/roles/github/defaults/main.yml
@@ -23,10 +23,9 @@ github_final_hook: ""
 
 github_buildx_inline_config: ""
 
-github_timeout: 360
-
 github_buildx_enable_provenance: false
 
+github_timeout: 360
 github_kayobe_limit_input: |
   kayobeLimit:
     description: |

--- a/roles/github/defaults/main.yml
+++ b/roles/github/defaults/main.yml
@@ -26,6 +26,7 @@ github_buildx_inline_config: ""
 github_buildx_enable_provenance: false
 
 github_timeout: 360
+
 github_kayobe_limit_input: |
   kayobeLimit:
     description: |

--- a/roles/github/templates/build-kayobe-docker-image.yml.j2
+++ b/roles/github/templates/build-kayobe-docker-image.yml.j2
@@ -57,6 +57,9 @@ jobs:
           tags: |
             %% github_registry_url %%/%% github_image_name %%:latest
             %% github_registry_url %%/%% github_image_name %%:${{ github.sha }}
+<% if not github_buildx_enable_provenance %>
+          provenance: false
+<% endif %>
 <% if github_final_hook | length >= 1 +%>
       %% github_final_hook | indent(width=6, first=false) -%%
 <% endif %>


### PR DESCRIPTION
Adds a flag to disable build attestations/provenance. This causes issues on some clouds and so is defaulted to `false`. Whether or not it is enabled can be chaged with the github_buildx_enable_provenance variable.