### PR TITLE
fix: prevent unwanted evaluation

### DIFF
--- a/roles/github/defaults/main.yml
+++ b/roles/github/defaults/main.yml
@@ -56,6 +56,7 @@ github_kolla_tags_input: |
       The ansible tags to use when running kolla-ansible playbooks.
 
 github_kayobe_environment_input: |
+  {%- if github_environment_selector == 'input' -%}
   kayobe_environment:
     description: |
       Select the environment the kayobe workflow shall target.
@@ -63,6 +64,7 @@ github_kayobe_environment_input: |
     required: true
     default: '{{ github_kayobe_environments | first }}'
     options: {{ github_kayobe_environments }}
+  {%- endif -%}
 
 github_workflows:
   - "{{ github_prepare_runner }}"


### PR DESCRIPTION
In older versions of Ansible it attempts to evaluate the nested variable inside `github_kayobe_environment_input` this causes the role to fail if using no environments.

This highlights the need to adapt the test workflow to run against other versions of Ansible.