### PR TITLE
feat!: update `github_default_registry`

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: stackhpc
 name: kayobe_workflows
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.1
+version: 1.0.2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/github/README.md
+++ b/roles/github/README.md
@@ -46,7 +46,7 @@ The following variables can be used to make small adjustments to the composition
 
 `github_image_tag`: tag used to select kayobe image defaults to `latest`
 
-`github_registry`: dictionary containing keys that correspond to `url`, `username`, `password` and `share` for the registry to be used by the workflows. By default it use repository varialbes and settings `REGISTRY_URL`, `REGISTRY_USERNAME`, `REGISTRY_PASSWORD`. The key `share` is to indiciate if the registry is shared between environments.
+`github_registry`: dictionary containing keys that correspond to `url`, `username`, `password` and `share` for the registry to be used by the workflows. By default it uses repository variables and settings `REGISTRY_URL`, `REGISTRY_USERNAME`, `REGISTRY_PASSWORD`. The key `share` is to indiciate if the registry is shared between environments.
 
 `github_kayobe_base_image`: select the base image used when building the kayobe docker image. Default is `quay.io/centos/centos:stream8` supports OpenStack Wallaby, Xena and Yoga. Zed and higher would require `quay.io/rockylinux/rockylinux:9`.
 

--- a/roles/github/README.md
+++ b/roles/github/README.md
@@ -46,7 +46,7 @@ The following variables can be used to make small adjustments to the composition
 
 `github_image_tag`: tag used to select kayobe image defaults to `latest`
 
-`github_registry`: dictionary containing keys that correspond to `url`, `username`, `password` and `share` for the registry to be used by the workflows. Defaults to `ghcr.io` and uses the actors token to login. The key `share` is to indiciate if the registry is shared between environments.
+`github_registry`: dictionary containing keys that correspond to `url`, `username`, `password` and `share` for the registry to be used by the workflows. By default it use repository varialbes and settings `REGISTRY_URL`, `REGISTRY_USERNAME`, `REGISTRY_PASSWORD`. The key `share` is to indiciate if the registry is shared between environments.
 
 `github_kayobe_base_image`: select the base image used when building the kayobe docker image. Default is `quay.io/centos/centos:stream8` supports OpenStack Wallaby, Xena and Yoga. Zed and higher would require `quay.io/rockylinux/rockylinux:9`.
 

--- a/roles/github/vars/main.yml
+++ b/roles/github/vars/main.yml
@@ -1,8 +1,8 @@
 ---
 github_default_registry:
-  url: ghcr.io
-  username: !unsafe "${{ github.actor }}"
-  password: !unsafe "${{ secrets.GITHUB_TOKEN }}"
+  url: !unsafe "${{ vars.REGISTRY_URL }}"
+  username: !unsafe "${{ vars.REGISTRY_USERNAME }}"
+  password: !unsafe "${{ secrets.REGISTRY_PASSWORD }}"
   share: false
 
 github_default_kayobe_arguments:


### PR DESCRIPTION
The URL, username and password have been changed to use repository variables and secrets by default. This is has been done to simplify deployment as the steps would be the same regardless of single environment or multiple environment.