### PR TITLE
feat: template out `uid` and `gid` for kayobe image

### DIFF
--- a/roles/github/README.md
+++ b/roles/github/README.md
@@ -36,6 +36,10 @@ The following variables can be used to make small adjustments to the composition
 
 `github_output_directory`: control the location where the workflows shall be written to.
 
+`github_kayobe_user_id`: set the user id when building the kayobe docker image. Default is `1000`
+
+`github_kayobe_group_id`: set the group id when building the kayobe docker image. Default is `1000` 
+
 `github_environment_selector`: control the type of environment support the workflows should be generated with. Either `single` for fixed environment or `input` whereby the environment is controlled at `workflow_dispatch`. No environment is the default by setting `github_environment_selector` to no value or `Null`.
 
 `github_kayobe_environments`: list of environments the workflows should target. Only has effect when `github_environment_selector` is `input` or `single`.

--- a/roles/github/defaults/main.yml
+++ b/roles/github/defaults/main.yml
@@ -1,6 +1,10 @@
 ---
 github_output_directory: .github/workflows
 
+github_kayobe_user_id: 1000
+
+github_kayobe_group_id: 1000
+
 github_environment_selector:
 
 github_kayobe_environments: []

--- a/roles/github/templates/build-kayobe-docker-image.yml.j2
+++ b/roles/github/templates/build-kayobe-docker-image.yml.j2
@@ -10,8 +10,8 @@ on:
   workflow_dispatch:
 
 env:
-  KAYOBE_USER_UID: 1000
-  KAYOBE_USER_GID: 1000
+  KAYOBE_USER_UID: %% github_kayobe_user_id %%
+  KAYOBE_USER_GID: %% github_kayobe_group_id %%
 
 jobs:
   prepare-runner:


### PR DESCRIPTION
Currently the `KAYOBE_USER_UID` and `KAYOBE_GROUP_UID` are hardcoded to `1000` is fine if you are deploying within a bespoke host and using the default user account. However, this is not always the case and situations might dictate that alternative user and group IDs are used instead.

This PR resolves this issue by allowing them to be customised avoiding situations whereby the workflows are edited by hand after being generated.