### PR TITLE
feat: allow `http_proxy` and `https_proxy` to be set

### DIFF
--- a/roles/github/README.md
+++ b/roles/github/README.md
@@ -50,6 +50,8 @@ The following variables can be used to make small adjustments to the composition
 
 `github_kayobe_base_image`: select the base image used when building the kayobe docker image. Default is `quay.io/centos/centos:stream8` supports OpenStack Wallaby, Xena and Yoga. Zed and higher would require `quay.io/rockylinux/rockylinux:9`.
 
+`github_kayobe_http_proxy`: specify a HTTP proxy to be used during the kayobe container image build. The same setting is applied for HTTPS.
+
 `github_kayobe_arguments`: a dictionary of arguments that can be used to override the default arguments found within `vars/main.yml`. For example if you wanted to change the value of `KAYOBE_AUTOMATION_PR_TITLE` from its default, you can do by simply adding `KAYOBE_AUTOMATION_PR_TITLE` to this dictionary and it will take precedence over the default.
 
 `github_*_hook:` see section [Template Hooks](#template-hooks)  for information about this variables

--- a/roles/github/defaults/main.yml
+++ b/roles/github/defaults/main.yml
@@ -15,6 +15,8 @@ github_image_tag: !unsafe "${{ needs.prepare-runner.outputs.openstack_release }}
 
 github_kayobe_base_image: "quay.io/centos/centos:stream8"
 
+github_kayobe_http_proxy: ""
+
 github_kayobe_arguments: {}
 
 github_checkout_hook: ""

--- a/roles/github/templates/build-kayobe-docker-image.yml.j2
+++ b/roles/github/templates/build-kayobe-docker-image.yml.j2
@@ -68,10 +68,14 @@ jobs:
           file: ./docker-image-build/.automation/docker/kayobe/Dockerfile
           context: docker-image-build
           build-args: |
-             KAYOBE_DOCKER_SSH_CONFIG_PATH=.automation/docker/kayobe/ssh_config
-             KAYOBE_USER_UID=${{ env.KAYOBE_USER_UID }}
-             KAYOBE_USER_GID=${{ env.KAYOBE_USER_UID }}
-             BASE_IMAGE=%% github_kayobe_base_image %%
+            KAYOBE_DOCKER_SSH_CONFIG_PATH=.automation/docker/kayobe/ssh_config
+            KAYOBE_USER_UID=${{ env.KAYOBE_USER_UID }}
+            KAYOBE_USER_GID=${{ env.KAYOBE_USER_UID }}
+            BASE_IMAGE=%% github_kayobe_base_image %%
+<% if github_kayobe_http_proxy | length >= 1 %>
+            http_proxy=%% github_kayobe_http_proxy %%
+            https_proxy=%% github_kayobe_http_proxy %%
+<% endif %>
           push: true
           tags: |
             %% github_registry.url | default(github_default_registry.url) %%/%% github_image_name %%:%% github_image_tag %%


### PR DESCRIPTION
In some deployments it may be necessary to use `HTTP` and `HTTPS` proxies in order to allow the kayobe image to be built.

Requires: https://github.com/stackhpc/kayobe-automation/pull/45