### PR TITLE
feat: upload `diff` and `log` artifacts after `config-diff`

### DIFF
--- a/roles/github/templates/run-config-diff.yml.j2
+++ b/roles/github/templates/run-config-diff.yml.j2
@@ -73,6 +73,15 @@ jobs:
       - name: Print diff
         run: |
           cat /tmp/kayobe-config-diff
+      
+      - name: Build artifact
+        uses: actions/upload-artifact@v3
+        with:
+         name: config-diff-artifacts
+         path: |
+           /tmp/kayobe-config-diff
+           /tmp/target-kayobe.log
+           /tmp/source-kayobe.log
 <% if github_final_hook | length >= 1 +%>
       %% github_final_hook | indent(width=6, first=false) -%%
 <% endif %>

--- a/roles/github/templates/run-config-diff.yml.j2
+++ b/roles/github/templates/run-config-diff.yml.j2
@@ -74,8 +74,8 @@ jobs:
         run: |
           cat /tmp/kayobe-config-diff
       
-      - name: Build artifact
-        uses: actions/upload-artifact@v3
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
         with:
          name: config-diff-artifacts
          path: |


### PR DESCRIPTION
If running kayobe-automation with the following change present https://github.com/stackhpc/kayobe-automation/pull/55 it would be benefical to upload the ansible logs of the two configurations that have been generated. This is because the change in kayobe-automation generates the two configs in parallel and as a result only the new configuration is shown in stdout. This change ensures that there is a way to have a detailed of both configurations and which will help if the hidden output contains an error message.