### PR TITLE
Update and pin versions of actions and images

### DIFF
--- a/roles/github/templates/build-kayobe-docker-image.yml.j2
+++ b/roles/github/templates/build-kayobe-docker-image.yml.j2
@@ -24,7 +24,7 @@ jobs:
     <%- endif +%>
     runs-on: %% github_runs_on %%
     container:
-      image: docker:24.0-git
+      image: docker:%% github_docker_container_version %%
     permissions:
       contents: read
       packages: %% 'write' if (github_registry.url | default(github_default_registry.url)) == 'ghcr.io' else 'none' %%
@@ -34,13 +34,13 @@ jobs:
       %% github_checkout_hook | indent(width=6, first=false) %%
 <% endif %>
       - name: Checkout kayobe config
-        uses: actions/checkout@v3
+        uses: actions/checkout@%% github_actions_checkout_version %%
         with:
            submodules: true
            path: docker-image-build
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@%% github_docker_login_action_version %%
         with:
           registry: %% github_registry.url | default(github_default_registry.url) %%
           username: %% github_registry.username | default(github_default_registry.username) %%
@@ -48,22 +48,22 @@ jobs:
 
 <% if github_buildx_enabled %>
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@%% github_docker_setup_buildx_action_version %%
         with:
           driver-opts: |
-            image=moby/buildkit:v0.12.1
+            image=moby/buildkit:%% github_buildkit_image_version %%
 <% if github_buildx_inline_config | length >= 1 %>
           config-inline: |
             %% github_buildx_inline_config | indent(12) | trim %%
 <% endif %>
-          version: v0.11.2
+          version: %% github_buildx_version %%
 
 <% endif %>
 <% if github_kayobe_hook | length >= 1 %>
       %% github_kayobe_hook | indent(width=6, first=false) %%
 <% endif %>
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@%% github_docker_build_push_action_version %%
         with:
           file: ./docker-image-build/.automation/docker/kayobe/Dockerfile
           context: docker-image-build

--- a/roles/github/templates/generic.yml.j2
+++ b/roles/github/templates/generic.yml.j2
@@ -36,7 +36,7 @@ jobs:
       %% github_checkout_hook | indent(width=6, first=false) %%
 <% endif %>
       - name: Checkout kayobe config
-        uses: actions/checkout@v3
+        uses: actions/checkout@%% github_actions_checkout_version %%
         with:
           submodules: true
           path: kayobe-config

--- a/roles/github/templates/prepare-runner.yml.j2
+++ b/roles/github/templates/prepare-runner.yml.j2
@@ -19,7 +19,7 @@ jobs:
       openstack_release: ${{ steps.openstack_release.outputs.openstack_release }}
     steps:
       - name: Checkout kayobe config
-        uses: actions/checkout@v3
+        uses: actions/checkout@%% github_actions_checkout_version %%
 
       - name: Extract OpenStack Release
         id: openstack_release

--- a/roles/github/templates/run-config-diff.yml.j2
+++ b/roles/github/templates/run-config-diff.yml.j2
@@ -41,7 +41,7 @@ jobs:
       %% github_checkout_hook | indent(width=6, first=false) %%
 <% endif %>
       - name: Checkout kayobe config
-        uses: actions/checkout@v3
+        uses: actions/checkout@%% github_actions_checkout_version %%
         with:
            submodules: true
            path: kayobe-config
@@ -75,7 +75,7 @@ jobs:
           cat /tmp/kayobe-config-diff
       
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@%% github_actions_upload_artifact_version %%
         with:
          name: config-diff-artifacts
          path: |

--- a/roles/github/templates/run-tempest.yml.j2
+++ b/roles/github/templates/run-tempest.yml.j2
@@ -38,7 +38,7 @@ jobs:
       %% github_checkout_hook | indent(width=6, first=false) %%
 <% endif %>
       - name: Checkout kayobe config
-        uses: actions/checkout@v3
+        uses: actions/checkout@%% github_actions_checkout_version %%
         with:
           submodules: true
           path: kayobe-config
@@ -47,7 +47,7 @@ jobs:
         run: sudo ln -s $PWD/kayobe-config /src
 
       - name: Get Previous Workflow Run
-        uses: actions/github-script@v6
+        uses: actions/github-script@%% github_actions_github_script_version %%
         id: get_previous_run
         if: ${{ inputs.run_previous_failed }}
         with:
@@ -67,7 +67,7 @@ jobs:
           result-encoding: string
 
       - name: Download previous Tempest test artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@%% github_actions_download_artifact_version %%
         id: previous_artifacts
         if: ${{ inputs.run_previous_failed }}
         with:
@@ -101,7 +101,7 @@ jobs:
           cat /stack/tempest-artifacts/stdout.log || echo "stdout.log is missing"
 
       - name: Build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@%% github_actions_upload_artifact_version %%
         with:
          name: tempest-artifacts
          path: |
@@ -116,7 +116,7 @@ jobs:
 <% endif %>
 
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@db71d41eb79864e25ab0337e395c352e84523afe # v4.3.1
+        uses: mikepenz/action-junit-report@%% github_mikepenz_action_junit_report_version %%
         if: success() || failure()
         with:
           report_paths: /stack/tempest-artifacts/rally-junit.xml

--- a/roles/github/vars/main.yml
+++ b/roles/github/vars/main.yml
@@ -48,3 +48,25 @@ github_kayobe_pull_request_arguments:
   - KAYOBE_AUTOMATION_PR_TYPE
   - KAYOBE_AUTOMATION_PR_TITLE
   - KAYOBE_AUTOMATION_PR_URL
+
+github_docker_image_version: "27.3.1"
+
+github_actions_checkout_version: "v4.2.0"
+
+github_docker_login_action_version: "v3.3.0"
+
+github_docker_setup_buildx_action_version: "v3.6.1"
+
+github_buildkit_image_version: "v0.16.0"
+
+github_buildx_version: "v0.17.1"
+
+github_docker_build_push_action_version: "v6.7.0"
+
+github_actions_upload_artifact_version: "v4.4.0"
+
+github_actions_github_script_version: "v7.0.1"
+
+github_actions_download_artifact_version: "v4.1.8"
+
+github_mikepenz_action_junit_report_version: "db71d41eb79864e25ab0337e395c352e84523afe" # v4.3.1


### PR DESCRIPTION
Update and pin the versions of all actions and images used within the workflows.

Motivation for this is to appease the deprication warnings due to older version of NodeJS and to make updating them in the future easier.